### PR TITLE
Fix typos and add better wording for PT-BR version

### DIFF
--- a/index-pt-br.html
+++ b/index-pt-br.html
@@ -70,7 +70,7 @@ Os organizadores vão reforçar que este código seja seguido durante todo o eve
 
 <h2>Precisa de ajuda?</h2>
 
-<p>Você tem os nossos contatos nos e-mails previamente enviados.</p>
+<p>Você tem os nossos contatos nos emails previamente enviados.</p>
 
 <h2>Versão rápida</h2>
 
@@ -78,30 +78,29 @@ Os organizadores vão reforçar que este código seja seguido durante todo o eve
   Nossa conferência é dedicada a fornecer uma experiência de conferência livre de assédio para todos,
   independentemente do sexo, identidade de gênero e expressão, idade, orientação sexual, deficiência,
   aparência física, tamanho corporal, cor de pele, etnia, religião (ou falta dela) ou escolhas de tecnologias.
-  Nós não toleramos o assédio dos participantes da conferência, sob qualquer forma. Linguagem e imagens sexuais
-  não são apropriadas para qualquer local da conferência, incluindo palestras, workshops, festas, Twitter e
-  outras mídias on-line. Os participantes que violem estas regras podem ser punidos ou expulsos da conferência
+  Nós não toleramos o assédio aos participantes da conferência, sob qualquer forma. Linguagem e imagens sexuais
+  não são apropriadas em nenhum local da conferência, incluindo palestras, workshops, festas, Twitter e
+  outras mídias on-line. Os participantes que violarem estas regras poderão ser punidos ou expulsos da conferência
   <em>sem restituição</em>, a critério dos organizadores da conferência.
 </p>
 
 <h2>Versão mais longa</h2>
 <p>
-  O assédio inclui comentários verbais ofensivos relacionados ao gênero, identidade de gênero e expressão,
+  Assédio inclui comentários verbais ofensivos relacionados ao gênero, identidade de gênero e expressão,
   idade, orientação sexual, deficiência, aparência física, tamanho corporal, cor de pele, etnia, religião, escolhas
-  de tecnologias, imagens  sexuais em espaços públicos, intimidação deliberada, perseguição, <em>stalking</em>,
+  de tecnologias, imagens sexuais em espaços públicos, intimidação deliberada, perseguição, <em>stalking</em>,
   fotografias ou filmagens constrangedoras, interrupção contínua das apresentações ou outros eventos, contato
-  físico inadequado, e atenção sexual indesejada.
+  físico inadequado e atenção sexual indesejada.
 </p>
 
 <p>
-  Os participantes que sejam solicitados a interromperem qualquer comportamento de assédio devem cumprir
-  a solicitação imediatamente.
+  Os participantes que receberem uma solicitação para interromper qualquer comportamento de assédio devem fazê-lo imediatamente.
 </p>
 
 <p>
-  Os patrocinadores também estão sujeitos às políticas anti-assédio. Em particular, os patrocinadores
-  não deve usar imagens, atividades ou outro material de cunho sexual. As equipes de estandes e tendas
-  (incluindo voluntários) não devem utilizar usar roupas, uniformes ou trajes sexualizados, ou de outra forma
+  Os patrocinadores também estão sujeitos às políticas antiassédio. Particularmente, os patrocinadores
+  não devem usar imagens, atividades ou outro material de cunho sexual. As equipes de estandes e tendas
+  (incluindo voluntários) não devem utilizar usar roupas, uniformes ou trajes sexualizados ou de outra forma
   criar um ambiente sexualizado.
 </p>
 
@@ -112,15 +111,15 @@ Os organizadores vão reforçar que este código seja seguido durante todo o eve
 </p>
 
 <p>
-  Caso seja assediado, ou perceber que alguém está sendo assediado, ou tiver alguma dúvida, entre
-  em contato com um membro da equipe da conferência imediatamente. A equipe da conferência pode ser
-  identificada pelas pessoas que estiverem vestindo camisetas marcadas.
+  Caso seja assediado, perceba que alguém está sendo assediado ou tenha alguma dúvida, entre
+  em contato com um membro da equipe da conferência imediatamente. Membros da equipe da conferência podem ser
+  identificados pois estarão vestindo camisetas marcadas.
 </p>
 
 <p>
   A equipe da conferência estará disposta a auxiliar os participantes a contatarem a segurança do hotel ou
-  local, assim como as devidas aplicações da lei local, fornecer escoltas, ou ajudar aqueles que sofrerem
-  assédio para se sintam seguros pelo o decorrer da conferência. Nós valorizamos o seu atendimento.
+  local, assim como as devidas aplicações da lei local, fornecer escoltas ou ajudar aqueles que sofrerem
+  assédio para se sintam seguros pelo o decorrer da conferência. Nós valorizamos a sua participação.
 </p>
 
 <p>


### PR DESCRIPTION
The current Brazilian Portuguese translation matches the original English document pretty closely, but some statements were translated literally, and don't sound good or are grammatically incorrect.

Some wording was changed to ensure the document matches the original English version and complies with Brazilian Portuguese grammar/orthography (e.g. no Oxford comma). Also, some typos fixed.
